### PR TITLE
fix: Move json-server para dependencies no package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "delay": 100
   },
   "dependencies": {
-    "edit-json-file": "^1.6.2"
+    "edit-json-file": "^1.6.2",
+    "json-server": "^0.17.0"
   },
   "devDependencies": {
-    "json-server": "^0.17.0",
     "nodemon": "^2.0.15"
   }
 }


### PR DESCRIPTION
A biblioteca é necessária durante a execução do projeto.